### PR TITLE
Upgrade oauth2-proxy to v7.2.0

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,8 +9,8 @@ on:
 
 env:
   IMAGE_NAME: ${{ github.event.repository.name }}
-  VERSION: '7.1.3'
-  SHA256: 'a491ca18059848c356935fe2ca9e665faafe4bba3ee1ecbac5a5f5f193195a82'
+  VERSION: '7.2.0'
+  SHA256: 'db0f19b7d5533aecdbb352d0bbbf26a85733b74729d74a68babe7b3d7a69496b'
 
 jobs:
   build-push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,8 @@ on:
 
 env:
   IMAGE_NAME: ${{ github.event.repository.name }}
-  VERSION: '7.1.3'
-  SHA256: 'a491ca18059848c356935fe2ca9e665faafe4bba3ee1ecbac5a5f5f193195a82'
+  VERSION: '7.2.0'
+  SHA256: 'db0f19b7d5533aecdbb352d0bbbf26a85733b74729d74a68babe7b3d7a69496b'
 
 jobs:
   build-push:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:8 as build
 
-ARG OAUTH2_PROXY_VERSION=v7.1.3
-ARG OAUTH2_PROXY_SHA256=a491ca18059848c356935fe2ca9e665faafe4bba3ee1ecbac5a5f5f193195a82
+ARG OAUTH2_PROXY_VERSION=v7.2.0
+ARG OAUTH2_PROXY_SHA256=db0f19b7d5533aecdbb352d0bbbf26a85733b74729d74a68babe7b3d7a69496b
 
 RUN curl -L -O https://github.com/oauth2-proxy/oauth2-proxy/releases/download/${OAUTH2_PROXY_VERSION}/oauth2-proxy-${OAUTH2_PROXY_VERSION}.linux-amd64.tar.gz \
     \
@@ -9,7 +9,7 @@ RUN curl -L -O https://github.com/oauth2-proxy/oauth2-proxy/releases/download/${
     && echo "${OAUTH2_PROXY_SHA256} oauth2-proxy-${OAUTH2_PROXY_VERSION}.linux-amd64.tar.gz" | sha256sum -c \
     && tar -zxvf oauth2-proxy-${OAUTH2_PROXY_VERSION}.linux-amd64.tar.gz  \
     \
-    && mv oauth2-proxy-v7.1.3.linux-amd64/oauth2-proxy /usr/local/bin/oauth2-proxy \
+    && mv oauth2-proxy-v7.2.0.linux-amd64/oauth2-proxy /usr/local/bin/oauth2-proxy \
     && rm -rf oauth2-proxy-${OAUTH2_PROXY_VERSION}.linux-amd64.tar.gz
 
 RUN touch /jwt_signing_key.pem

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Docker image build for [oauth2-proxy](https://oauth2-proxy.github.io/oauth2-prox
 
 ### Images
 
-- docker pull docker.io/containerinfra/oauth2-proxy:7.1.3
-- docker pull ghcr.io/containerinfra/oauth2-proxy:7.1.3
+- docker pull docker.io/containerinfra/oauth2-proxy:7.2.0
+- docker pull ghcr.io/containerinfra/oauth2-proxy:7.2.0
 
 ### Verify image with cosign
 
@@ -29,8 +29,8 @@ eQm/6XSWAMDGeH4hrFpvo8Sw0t+xf0PdRSUEXCyKFXve+Q2s8csVo4eAaA==
 -----END PUBLIC KEY-----
 
 
-cosign verify --key cosign.pub docker.io/containerinfra/oauth2-proxy:7.1.3
-cosign verify --key cosign.pub ghcr.io/containerinfra/oauth2-proxy:7.1.3
+cosign verify --key cosign.pub docker.io/containerinfra/oauth2-proxy:7.2.0
+cosign verify --key cosign.pub ghcr.io/containerinfra/oauth2-proxy:7.2.0
 ```
 
 ### Configuration


### PR DESCRIPTION
This upgrades the oauth2-proxy to v7.2.0.

Signed-off-by: Thomas Kooi <thomasjkooi@gmail.com>
